### PR TITLE
hardkernel odroid h4: bump version to 0.9.1

### DIFF
--- a/configs/hardkernel.json
+++ b/configs/hardkernel.json
@@ -7,7 +7,7 @@
       "bucket_dpp": "dasharo-odroid-h4-plus-uefi",
       "bucket_dpp_slimuefi": "dasharo-odroid-h4-plus-slim-bootloader-uefi",
       "dasharo_rel_name": "hardkernel_odroid_h4",
-      "dasharo_rel_ver_dpp": "0.9.0",
+      "dasharo_rel_ver_dpp": "0.9.1",
       "coreboot_uefi_to_slim_bootloader_uefi_transition": "true",
       "dasharo_rel_ver_dpp_slimuefi": "0.9.0"
     }


### PR DESCRIPTION
Bump firmware version to 0.9.1 for Odroid H4.