### PR TITLE
configs: notebook: bump ADL firmware to v1.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# The directory created by the scripts/create_dir_structure.sh script:
+test-server

--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ can_use_flashrom
 Not all system models are divided into board models, sometimes the
 `board_models` dictionary might be absent in the JSON files.
 
+## Contribution
+
+There are two important branches:
+
+* `main`: contains metadata that are used by DTS end-users to update or
+  install Dasharo firmware using DTS.
+* `develop`: contains metadata that are used by CI/CDs when testing DTS.
+
+The `main` branch can be behind `develop` (for example, when the metadata
+should be tested by CI/CDs before merging to `main`). But `develop` must not be
+behind `main` unless there is a specific reason. Note that `develop` should not
+be rebased. Instead, when opening a PR to `main` and after merging it - open a
+PR from `main` to `develop`.
+
 ## Example changes
 
 Bumping the firmware revision for an existing board (`Odroid H4+`):

--- a/configs/notebook.json
+++ b/configs/notebook.json
@@ -15,7 +15,7 @@
       "CAN_INSTALL_BIOS": "true",
       "COMPATIBLE_EC_FW_VERSION": "2022-10-07_c662165",
       "bios_path_comm": "novacustom_nv4x_tgl/v1.5.2/novacustom_nv4x_tgl_v1.5.2.rom",
-      "ec_path_comm": "novacustom_nv4x_tgl/v1.5.2/novacustom_nv4x_tgl_ec_v1.5.2.rom"
+      "ec_path_comm":   "novacustom_nv4x_tgl/v1.5.2/novacustom_nv4x_tgl_ec_v1.5.2.rom"
     },
 
     "ns50_70mu": {
@@ -25,34 +25,44 @@
       "compatible_ec_fw_version": "2022-08-31_cbff21b",
       "programmer_ec": "ite_ec:romsize=128K,autoload=disable",
       "bios_path_comm": "novacustom_ns5x_tgl/v1.5.2/novacustom_ns5x_tgl_v1.5.2.rom",
-      "ec_path_comm": "novacustom_ns5x_tgl/v1.5.2/novacustom_ns5x_tgl_ec_v1.5.2.rom"
+      "ec_path_comm":   "novacustom_ns5x_tgl/v1.5.2/novacustom_ns5x_tgl_ec_v1.5.2.rom"
     },
 
     "ns5x_ns7xpu" : {
       "dasharo_rel_name": "novacustom_ns5x_adl",
-      "dasharo_rel_ver": "1.7.2",
-      "compatible_ec_fw_version": "2022-08-31_cbff21b",
-      "bios_path_comm": "novacustom_ns5x_adl/v1.7.2/novacustom_ns5x_adl_v1.7.2.rom",
-      "ec_path_comm": "novacustom_ns5x_adl/v1.7.2/novacustom_ns5x_adl_ec_v1.7.2.rom"
+      "dasharo_rel_ver":                   "1.8.0",
+      "dasharo_rel_ver_cap":               "1.8.0",
+      "dasharo_support_cap_from":          "1.8.0",
+      "dasharo_support_cap_with_fum_from": "1.8.0",
+      "compatible_ec_fw_version": "2025-10-31_af6bd04",
+      "bios_path_comm":     "novacustom_ns5x_adl/uefi/v1.8.0/novacustom_ns5x_adl_v1.8.0_btg_prod.rom",
+      "ec_path_comm":       "novacustom_ns5x_adl/uefi/v1.8.0/novacustom_ns5x_adl_ec_v1.8.0.rom",
+      "eom_path_comm_cap":  "novacustom_ns5x_adl/uefi/v1.8.0/novacustom_ns5x_adl_v1.8.0_btg_prod_eom.cap",
+      "intel_btg_hash": "c33719478dd42ca987ace37348aa4a00c77a56423a7727c5f7b703e81d72710ef4c00fc740383f2baa866ef48bd57148"
     },
 
     "nv4xpz": {
       "dasharo_rel_name": "novacustom_nv4x_adl",
-      "dasharo_rel_ver": "1.7.2",
-      "heads_rel_ver_dpp": "0.9.2",
+      "dasharo_rel_ver":                   "1.8.0",
+      "dasharo_rel_ver_cap":               "1.8.0",
+      "dasharo_support_cap_from":          "1.8.0",
+      "dasharo_support_cap_with_fum_from": "1.8.0",
+      "heads_rel_ver_dpp":                 "0.9.2",
       "heads_switch_flashrom_opt_override": "--ifd -i bios",
-      "compatible_ec_fw_version": "2022-08-31_cbff21b",
-      "bios_path_comm": "novacustom_nv4x_adl/v1.7.2/novacustom_nv4x_adl_v1.7.2.rom",
-      "ec_path_comm": "novacustom_nv4x_adl/v1.7.2/novacustom_nv4x_adl_ec_v1.7.2.rom",
+      "compatible_ec_fw_version": "2025-10-31_af6bd04",
       "have_heads_fw": true,
-      "heads_link_dpp": "dasharo-novacustom-heads/novacustom_nv4x_adl/v0.9.2/novacustom_nv4x_adl_v0.9.2_heads.rom"
+      "bios_path_comm":     "novacustom_nv4x_adl/uefi/v1.8.0/novacustom_nv4x_adl_v1.8.0_btg_prod.rom",
+      "ec_path_comm":       "novacustom_nv4x_adl/uefi/v1.8.0/novacustom_nv4x_adl_ec_v1.8.0.rom",
+      "eom_path_comm_cap":  "novacustom_nv4x_adl/uefi/v1.8.0/novacustom_nv4x_adl_v1.8.0_btg_prod_eom.cap",
+      "heads_link_dpp":     "dasharo-novacustom-heads/novacustom_nv4x_adl/v0.9.2/novacustom_nv4x_adl_v0.9.2_heads.rom",
+      "intel_btg_hash": "c33719478dd42ca987ace37348aa4a00c77a56423a7727c5f7b703e81d72710ef4c00fc740383f2baa866ef48bd57148"
     },
 
     "v54x_6x_tu": {
-      "dasharo_rel_ver": "1.0.1",
-      "dasharo_rel_ver_cap": "1.0.1",
+      "dasharo_rel_ver":          "1.0.1",
+      "dasharo_rel_ver_cap":      "1.0.1",
       "dasharo_support_cap_from": "1.0.0-rc7",
-      "heads_rel_ver_dpp": "0.9.0",
+      "heads_rel_ver_dpp":        "0.9.0",
       "have_heads_fw": true,
       "compatible_ec_fw_version": "2024-07-17_4ae73b9",
       "heads_switch_flashrom_opt_override": "--ifd -i bios",
@@ -83,8 +93,8 @@
     },
 
     "v5xtnc_tnd_tne": {
-      "dasharo_rel_ver": "1.0.0",
-      "dasharo_rel_ver_cap": "1.0.0",
+      "dasharo_rel_ver":          "1.0.0",
+      "dasharo_rel_ver_cap":      "1.0.0",
       "dasharo_support_cap_from": "1.0.0-rc7",
       "compatible_ec_fw_version": "2024-09-10_3786c8c",
       "programmer_bios": "internal:boardmismatch=force",

--- a/scripts/create_dir_structure.sh
+++ b/scripts/create_dir_structure.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+print_usage(){
+    echo "Usage: $(basename "${BASH_SOURCE[0]}") <path-to-dts-configs>
+
+Parses <dts-configs>/configs/*.json, extracts every value whose key
+contains _path_ or _link_ (or is exactly platform_sign_key), strips
+the last path element (which is a file), and creates the resulting
+directory tree under local-server directory. Then starts an HTTP
+server on port 8080."
+}
+
+if [[ $# -ne 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+    print_usage
+    exit 0
+fi
+
+CONFIGS_DIR="$(realpath "${1}")/configs"
+OUTPUT_BASE="./test-server"
+
+# ── dependency check ──────────────────────────────────────────────────────────
+for cmd in jq python3; do
+    if ! command -v "${cmd}" &>/dev/null; then
+        echo "Error: '${cmd}' is required but not installed." >&2
+        exit 1
+    fi
+done
+
+if [[ ! -d "${CONFIGS_DIR}" ]]; then
+    echo "Error: configs directory not found: ${CONFIGS_DIR}" >&2
+    print_usage
+    exit 1
+fi
+
+# ── jq filter ────────────────────────────────────────────────────────────────
+# Recurse into every object, pick values whose key:
+#   • contains "_path_" or "_link_", OR
+#   • is exactly "platform_sign_key"
+JQ_FILTER='
+  .. | objects | to_entries[] |
+  select(.key | (test("_path_|_link_") or . == "platform_sign_key")) |
+  .value | strings
+'
+
+# ── process each config file ──────────────────────────────────────────────────
+echo "Scanning : ${CONFIGS_DIR}"
+echo "Output   : ${OUTPUT_BASE}"
+echo
+
+for json_file in "${CONFIGS_DIR}"/*.json; do
+    config_name="$(basename "${json_file}" .json)"
+
+    echo "── ${config_name}.json"
+
+    while IFS= read -r raw_value; do
+        [[ -z "${raw_value}" ]] && continue
+
+        # platform_sign_key may hold space-separated paths — split on whitespace
+        for single_path in ${raw_value}; do
+            single_path="${single_path%/}"          # strip any trailing slash
+            dir_part="$(dirname "${single_path}")"  # last element is a file
+
+            # dirname returns "." for a bare filename with no directory part
+            [[ "${dir_part}" == "." ]] && continue
+
+            target="${OUTPUT_BASE}/${dir_part}"
+            if [[ ! -d "${target}" ]]; then
+                echo "   mkdir  ${dir_part}"
+                mkdir -p "${target}"
+            fi
+        done
+    done < <(jq -r "${JQ_FILTER}" "${json_file}" | sort -u)
+done
+
+echo
+echo "Directory structure complete."
+echo
+echo "Starting Python HTTP server on port 8080 (serving ${OUTPUT_BASE}) ..."
+echo "Press Ctrl-C to stop."
+echo
+
+cd "${OUTPUT_BASE}"
+exec python3 -m http.server 8080


### PR DESCRIPTION
@BeataZdunczyk, I have discussed whether there are other requirements apart from the firmware version change with @filipleple from Dasharo Team. Conclusions: the changes made in this PR are sufficient for Dasharo (coreboot+UEFI) update from 1.7.2 to 1.8.0 for Novacustom ADL laptops using DTS.

As discussed internally the DTS with metadata from this branch will be tested by Dasharo Team. To make DTS use metadata from this branch follow the steps:

1. Boot DTS.
2. Press `s` to enter shell.
3. Execute the following commands:

    ```bash
    export DTS_CONFIG_REF="refs/heads/adl-v-1-8-0"
    dts-boot
    ```

4. Perform the update.

In case the binaries are not on the production server yet. before the steps in DTS. 

1. Create the directory structure defined in your platform config and place the firmware files (including binaries, checksums and signatures) there.
2. Start simple HTTP server the will share the directories with files (e.g., `python -m http.server 8080`).
3. Before executing `dts-boot` in DTS - make sure to execute `export FW_STORE_URL_DEV="http://192.168.4.181:8080"` replacing the port and ip adress if needed.