### PR TITLE
docs: add generated platform mapping JSON for docs automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,16 @@ index 0000000..c5acffc
 +    }
 +  }
 +}
+
+## Docs mapping export (for issue #1576)
+
+To help generate DTS supported-hardware documentation, this repository now
+provides a generated mapping file:
+
+- `configs/docs_supported_platforms.json`
+
+Regenerate it after config updates with:
+
+```bash
+python3 tools/export_supported_platforms.py
+```

--- a/configs/docs_supported_platforms.json
+++ b/configs/docs_supported_platforms.json
@@ -1,0 +1,163 @@
+{
+  "generated_from": "configs/*.json",
+  "purpose": "Mapping between dmidecode-style identifiers and Dasharo release names for docs generation",
+  "count": 26,
+  "entries": [
+    {
+      "system_vendor": "3mdeb_test_config",
+      "system_model": "fum_cap_test",
+      "board_model": null,
+      "dasharo_rel_name": "novacustom_v54x_mtl_igpu"
+    },
+    {
+      "system_vendor": "asrock_industrial",
+      "system_model": "nuc box-125h",
+      "board_model": null,
+      "dasharo_rel_name": "novacustom_nuc_box_mtl"
+    },
+    {
+      "system_vendor": "hardkernel",
+      "system_model": "odroid-h4",
+      "board_model": null,
+      "dasharo_rel_name": "hardkernel_odroid_h4"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7d25",
+      "board_model": "pro z690-a (ms-7d25)",
+      "dasharo_rel_name": "msi_ms7d25"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7d25",
+      "board_model": "pro z690-a ddr4(ms-7d25)",
+      "dasharo_rel_name": "msi_ms7d25"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7d25",
+      "board_model": "pro z690-a wifi (ms-7d25)",
+      "dasharo_rel_name": "msi_ms7d25"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7d25",
+      "board_model": "pro z690-a wifi ddr4(ms-7d25)",
+      "dasharo_rel_name": "msi_ms7d25"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7e06",
+      "board_model": "pro z790-p (ms-7e06)",
+      "dasharo_rel_name": "msi_ms7e06"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7e06",
+      "board_model": "pro z790-p ddr4 (ms-7e06)",
+      "dasharo_rel_name": "msi_ms7e06"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7e06",
+      "board_model": "pro z790-p ddr4(ms-7e06)",
+      "dasharo_rel_name": "msi_ms7e06"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7e06",
+      "board_model": "pro z790-p wifi (ms-7e06)",
+      "dasharo_rel_name": "msi_ms7e06"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7e06",
+      "board_model": "pro z790-p wifi ddr4 (ms-7e06)",
+      "dasharo_rel_name": "msi_ms7e06"
+    },
+    {
+      "system_vendor": "micro-star_international_co.,_ltd.",
+      "system_model": "ms-7e06",
+      "board_model": "pro z790-p wifi ddr4(ms-7e06)",
+      "dasharo_rel_name": "msi_ms7e06"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "ns50_70mu",
+      "board_model": null,
+      "dasharo_rel_name": "novacustom_ns5x_tgl"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "ns5x_ns7xpu",
+      "board_model": null,
+      "dasharo_rel_name": "novacustom_ns5x_adl"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "nv4xmb,me,mz",
+      "board_model": null,
+      "dasharo_rel_name": "novacustom_nv4x_tgl"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "nv4xpz",
+      "board_model": null,
+      "dasharo_rel_name": "novacustom_nv4x_adl"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "v54x_6x_tu",
+      "board_model": "v540tu",
+      "dasharo_rel_name": "novacustom_v54x_mtl_igpu"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "v54x_6x_tu",
+      "board_model": "v560tu",
+      "dasharo_rel_name": "novacustom_v56x_mtl_igpu"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "v5xtnc_tnd_tne",
+      "board_model": "v540tnx",
+      "dasharo_rel_name": "novacustom_v54x_mtl_dgpu"
+    },
+    {
+      "system_vendor": "notebook",
+      "system_model": "v5xtnc_tnd_tne",
+      "board_model": "v560tnx",
+      "dasharo_rel_name": "novacustom_v56x_mtl_dgpu"
+    },
+    {
+      "system_vendor": "novacustom",
+      "system_model": "nuc_box",
+      "board_model": null,
+      "dasharo_rel_name": "novacustom_nuc_box_mtl"
+    },
+    {
+      "system_vendor": "pc_engines",
+      "system_model": "apu2",
+      "board_model": null,
+      "dasharo_rel_name": "pcengines_apu2"
+    },
+    {
+      "system_vendor": "pc_engines",
+      "system_model": "apu3",
+      "board_model": null,
+      "dasharo_rel_name": "pcengines_apu3"
+    },
+    {
+      "system_vendor": "pc_engines",
+      "system_model": "apu4",
+      "board_model": null,
+      "dasharo_rel_name": "pcengines_apu4"
+    },
+    {
+      "system_vendor": "pc_engines",
+      "system_model": "apu6",
+      "board_model": null,
+      "dasharo_rel_name": "pcengines_apu6"
+    }
+  ]
+}

--- a/tools/export_supported_platforms.py
+++ b/tools/export_supported_platforms.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+CONFIGS_DIR = Path(__file__).resolve().parents[1] / "configs"
+OUT_FILE = CONFIGS_DIR / "docs_supported_platforms.json"
+
+
+def extract_entries(vendor_file: Path):
+    data = json.loads(vendor_file.read_text())
+    vendor = vendor_file.stem
+    out = []
+    models = data.get("models", {})
+
+    for system_model, mdata in models.items():
+        base_rel = mdata.get("dasharo_rel_name") or mdata.get("DASHARO_REL_NAME")
+        boards = mdata.get("board_models", {})
+
+        if boards:
+            for board_model, bdata in boards.items():
+                rel = bdata.get("dasharo_rel_name") or bdata.get("DASHARO_REL_NAME") or base_rel
+                out.append({
+                    "system_vendor": vendor,
+                    "system_model": system_model,
+                    "board_model": board_model,
+                    "dasharo_rel_name": rel,
+                })
+        else:
+            out.append({
+                "system_vendor": vendor,
+                "system_model": system_model,
+                "board_model": None,
+                "dasharo_rel_name": base_rel,
+            })
+    return out
+
+
+def main():
+    entries = []
+    for cfg in sorted(CONFIGS_DIR.glob("*.json")):
+        if cfg.name == OUT_FILE.name:
+            continue
+        entries.extend(extract_entries(cfg))
+
+    entries = [e for e in entries if e.get("dasharo_rel_name")]
+    entries.sort(key=lambda e: (e["system_vendor"], e["system_model"], e["board_model"] or ""))
+
+    payload = {
+        "generated_from": "configs/*.json",
+        "purpose": "Mapping between dmidecode-style identifiers and Dasharo release names for docs generation",
+        "count": len(entries),
+        "entries": entries,
+    }
+    OUT_FILE.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"wrote {OUT_FILE} ({len(entries)} entries)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add a generated JSON mapping that can be used as input for DTS supported-hardware docs generation.

## What this adds
- `tools/export_supported_platforms.py`
  - parses `configs/*.json`
  - extracts `(system_vendor, system_model, board_model, dasharo_rel_name)`
  - writes deterministic output to `configs/docs_supported_platforms.json`
- `configs/docs_supported_platforms.json` (generated)
- README section describing regeneration command

## Why
Issue #1576 asks for a machine-readable mapping between dmidecode-like identifiers and docs platform naming so docs pages can be generated/updated more reliably.

This PR provides the first building block in `dts-configs` with minimal scope and no behavior change to DTS runtime.
